### PR TITLE
don't panic when querying to entity with mismatched archetype

### DIFF
--- a/src/resources/daslib_str/decs.das.inl
+++ b/src/resources/daslib_str/decs.das.inl
@@ -422,7 +422,6 @@
 "        ++insideQuery; invoke(blk, arch, lookup.index); -- insideQuery\n"
 "        return true\n"
 "    else\n"
-"        panic(\"archetype not found\")\n"
 "        return false\n"
 "\n"
 "def public for_each_archetype ( hash:ComponentHash; var erq : function<():EcsReq"


### PR DESCRIPTION
It should be normal behavior to query any entity by any archetype. In the case of mismatched archetype, simply do nothing:
query(eid) <| $(var health: float)
        health -= damage