### PR TITLE
Build entire dasbox using CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+.vscode
 dasbox.exe
 bin
 dasbox
 cmake_tmp
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,46 +2,88 @@ cmake_minimum_required(VERSION 3.15)
 project(dasbox)
 set(CMAKE_CONFIGURATION_TYPES "Release" "Debug")
 
+
+if (MSVC)
+  if (USE_MSVC_RUNTIME_LIBRARY_DLL)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
+endif()
+
+
 if(MSVC)
   add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-  if(DASBOX_USE_STATIC_STD_LIBS)
-    add_compile_options(
-      "$<$<CONFIG:RELEASE>:/MT>"
-      "$<$<CONFIG:DEBUG>:/MTd>"
-    )
-  endif()
 endif()
 
 add_definitions(-DSFML_STATIC)
 add_definitions(-DMINFFT_SINGLE)
 
 
+# daScript -------------------------------
+
+set(DAS_BUILD_TEST NO)
+set(DAS_BUILD_PROFILE NO)
+set(DAS_BUILD_TUTORIAL NO)
+set(DAS_GLFW_DISABLED YES)
+set(DAS_IMGUI_DISABLED YES)
+set(DAS_CLANG_BIND_DISABLED YES)
+set(DAS_BGFX_DISABLED YES)
+set(DAS_STBIMAGE_DISABLED YES)
+set(DAS_STBTRUETYPE_DISABLED YES)
+set(DAS_STDDLG_DISABLED YES)
+set(DAS_XBYAK_DISABLED YES)
+# set(DAS_BUILD_TOOLS NO) # <--- need to build tools to support generation build step in daScript modules
+set(DAS_CONFIG_INCLUDE_DIR "src")
+
+add_subdirectory(3rdParty/daScript)
+
+
+# zstd -------------------------------
+
+set(ZSTD_BUILD_PROGRAMS OFF)
+set(ZSTD_BUILD_SHARED OFF)
+set(ZSTD_MULTITHREAD_SUPPORT ON)
+set(ZSTD_USE_STATIC_RUNTIME ON)
+
+add_subdirectory(3rdParty/zstd/build/cmake)
+
+
+# SFML -------------------------------
+set(SFML_BUILD_EXAMPLES FALSE)
+set(BUILD_SHARED_LIBS FALSE)
+set(SFML_USE_STATIC_STD_LIBS TRUE)
+
+add_subdirectory(3rdParty/SFML)
+
+
+
 file(GLOB SRC
-  *.cpp
-  *.h
-  ../3rdParty/minfft/minfft.c
-  ../3rdParty/fs8/library/fs8.cpp
+  src/*.cpp
+  src/*.h
+  3rdParty/minfft/minfft.c
+  3rdParty/fs8/library/fs8.cpp
 )
 
 include_directories(
-  .
-  ../3rdParty/fs8/library
-  ../3rdParty/minfft
-  ../3rdParty/miniaudio
-  ../3rdParty/SFML/include
-  ../3rdParty/daScript/include
-  ../3rdParty/zstd/lib
+  src
+  3rdParty/fs8/library
+  3rdParty/minfft
+  3rdParty/miniaudio
+  3rdParty/SFML/include
+  3rdParty/daScript/include
+  3rdParty/zstd/lib
 )
 
 link_directories(
-  ../3rdParty/daScript/build
-  ../3rdParty/SFML/build/lib
-  ../3rdParty/zstd/build/cmake/build/lib
+  3rdParty/daScript/build
+  3rdParty/SFML/build/lib
+  3rdParty/zstd/build/cmake/build/lib
 )
 
 if(MSVC)
-  set(SRC ${SRC} icon/icon.rc)
-  link_directories(../3rdParty/SFML/extlibs/libs-msvc/x64)
+  set(SRC ${SRC} src/icon/icon.rc)
+  link_directories(3rdParty/SFML/extlibs/libs-msvc/x64)
 endif()
 
 
@@ -70,6 +112,7 @@ if(WIN32)
     debug sfml-system-s-d
     debug sfml-window-s-d
   )
+
 endif()
 
 if(UNIX)
@@ -101,3 +144,9 @@ if(UNIX)
     Xcursor
   )
 endif()
+
+
+set_target_properties(dasbox PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG "${PROJECT_SOURCE_DIR}/bin"
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE "${PROJECT_SOURCE_DIR}/bin"
+)

--- a/build_vs.impl.bat
+++ b/build_vs.impl.bat
@@ -63,58 +63,11 @@ for /f %%x in ('wmic path win32_localtime get /format:list ^| findstr "="') do s
 echo #pragma once> src\buildDate.h
 echo #define DASBOX_BUILD_DATE "%Day%.%Month%.%Year%">> src\buildDate.h
 
-rem ============ daScript ==============
-pushd 3rdParty\zstd\build\cmake
-rd /S /Q build
-mkdir build
-pushd build
-cmake -G %CMAKE_GEN_TARGET% ^
-    -DCMAKE_INSTALL_PREFIX=bin ^
-    -DCMAKE_INSTALL_LIBDIR=bin_lib ^
-    -DZSTD_BUILD_PROGRAMS:BOOL=OFF ^
-    -DZSTD_BUILD_SHARED:BOOL=OFF ^
-    -DZSTD_MULTITHREAD_SUPPORT:BOOL=ON ^
-    -DZSTD_USE_STATIC_RUNTIME:BOOL=ON ^
-    ..
-
-pushd lib
-msbuild libzstd_static.vcxproj /p:Configuration=%CONFIGURATION%
-popd
-popd
-popd
-
-rem ============ daScript ==============
-pushd 3rdParty\daScript
-rd /S /Q build
-mkdir build
-pushd build
-cmake -G %CMAKE_GEN_TARGET% -DDAS_BUILD_TOOLS:BOOL=NO -DDAS_BUILD_TEST:BOOL=NO -DDAS_BUILD_PROFILE:BOOL=NO -DDAS_BUILD_TUTORIAL:BOOL=NO -DDAS_CONFIG_INCLUDE_DIR:STRING="%CD%/src" ..
-msbuild libDaScript.vcxproj /p:Configuration=%CONFIGURATION%
-rem msbuild libDasModuleUriparser.vcxproj /p:Configuration=%CONFIGURATION%
-msbuild libUriParser.vcxproj /p:Configuration=%CONFIGURATION%
-popd
-popd
-
-rem ============ SFML ==================
-pushd 3rdParty\SFML
-rd /S /Q build
-mkdir build
-pushd build
-cmake -G %CMAKE_GEN_TARGET% -DSFML_BUILD_EXAMPLES=FALSE -DBUILD_SHARED_LIBS:BOOL=FALSE -DSFML_USE_STATIC_STD_LIBS:BOOL=TRUE ..
-msbuild ALL_BUILD.vcxproj /p:Configuration=%CONFIGURATION%
-popd
-popd
 
 rem ============ dasbox ================
 rd /S /Q cmake_tmp
-mkdir cmake_tmp
-pushd cmake_tmp
-cmake -G %CMAKE_GEN_TARGET% -DDASBOX_USE_STATIC_STD_LIBS:BOOL=TRUE ../src
+mkdir build
+pushd build
+cmake -G %CMAKE_GEN_TARGET% -DDASBOX_USE_STATIC_STD_LIBS:BOOL=TRUE ..
 msbuild dasbox.vcxproj /p:Configuration=%CONFIGURATION%
 popd
-
-rem ============ copy ==================
-mkdir bin
-copy cmake_tmp\%CONFIGURATION%\dasbox.exe bin
-
-

--- a/src/daScript/das_config.h
+++ b/src/daScript/das_config.h
@@ -52,6 +52,8 @@ namespace fs { bool is_path_string_valid(const char * path); }
 #  define DAS_SANITIZER  0
 #endif
 
+#if !DASCRIPT_STANDALONE
+
 #ifndef DAS_FATAL_LOG
 #  define DAS_FATAL_LOG  print_error
 #endif
@@ -60,6 +62,8 @@ namespace fs { bool is_path_string_valid(const char * path); }
                            // shutup MSVC compiler
 #  define DAS_FATAL_ERROR  false ? void(0) : print_error
 #endif
+
+#endif // DASCRIPT_STANDALONE
 
 #ifndef DAS_BIND_EXTERNAL
   #if defined(_WIN32) && defined(_WIN64)


### PR DESCRIPTION
Now generate project with all needed dependencies using CMake (not relying on build sequence in .bat file as before)
Also allows porting to non-Windows platforms.
This requires fixes from https://github.com/GaijinEntertainment/daScript/pull/251